### PR TITLE
Add feature to replace email header and remove external sender warning

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,8 @@
     "react",
     "@typescript-eslint",
     "office-addins",
-    "jsdoc"
+    "jsdoc", 
+    "jest"
   ],
   "parserOptions": {
     "ecmaVersion": 6,
@@ -16,11 +17,22 @@
   },
   "extends": [
     "plugin:office-addins/react",
-    "plugin:jsdoc/recommended"
+    "plugin:jsdoc/recommended",
+    "plugin:jest/recommended"
   ],
   "settings": {
     "react": {
       "version": "detect"
     }
+  },
+  "rules": {
+    "jsdoc/check-tag-names": [
+        // The Error level should be `error`, `warn`, or `off` (or 2, 1, or 0)
+        "warn",
+        // The options vary by rule, but are added to an options object:
+        {
+          "definedTags": ["jest-environment"]
+        }
+    ]
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
+  preset: "ts-jest",
+  testEnvironment: "node"
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5074,6 +5074,15 @@
         "get-stdin": "^6.0.0"
       }
     },
+    "eslint-plugin-jest": {
+      "version": "23.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.13.0.tgz",
+      "integrity": "sha512-AG18G0qFCgFOdhMibl4cTuKTCBVjzm/hEPYMOPCTj3Yh2GQ53q5u5Jj3a4nl1JH1BxqPsXIrZR1oRE+TdptfHw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^2.5.0"
+      }
+    },
     "eslint-plugin-jsdoc": {
       "version": "25.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-25.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "css-loader": "^3.0.0",
     "eslint": "^6.0.0",
     "eslint-config-office-addins": "^1.0.14",
+    "eslint-plugin-jest": "^23.13.0",
     "eslint-plugin-jsdoc": "^25.0.1",
     "eslint-plugin-office-addins": "^0.1.1",
     "eslint-plugin-react": "^7.16.0",

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -43,14 +43,11 @@ function reformatEmail(event) {
       // Do nothing if the there's an error getting the body
       if (result.status == Office.AsyncResultStatus.Failed) event.completed();
 
-      // TODO: Replace the quoted email header with a single line:
-      // E.g., On Thursday, April 23, 2020 at 4:15 PM Jane <jane@protonmail.ch> wrote:
-
-      // Add the quotes
+      // Process the email body
       if (emailFormat == Office.CoercionType.Html) {
-        var newBody = reformatEmailBody(result.value, preferences);
+        var newBody = reformatEmailBody(result.value, true, preferences);
       } else if (emailFormat == Office.CoercionType.Text) {
-        // TODO: handle plain text email
+        var newBody = reformatEmailBody(result.value, false, preferences);
       }
 
       // Write to the new body

--- a/src/commands/formatter.test.ts
+++ b/src/commands/formatter.test.ts
@@ -1,5 +1,50 @@
-import { addQuotesToEmail } from "./formatter";
+/**
+ * @jest-environment jsdom
+ */
+import {
+  getFontStyle,
+  getCitation,
+  removeEmailHeader,
+  addQuotesToEmail,
+  removeExternalSenderWarning
+} from "./formatter";
+
+var testHtmlBody =
+  '<div style="font-family: Verdana, Geneva, sans-serif; font-size: 10pt; color: rgb(0, 0, 0);"><br></div><div id="appendonsend"></div><div style="font-family:Verdana,Geneva,sans-serif; font-size:10pt; color:rgb(0,0,0)"><br></div><hr tabindex="-1" style="display:inline-block; width:98%"><div id="divRplyFwdMsg" dir="ltr"><font face="Calibri, sans-serif" color="#000000" style="font-size:11pt"><b>From:</b> John Smith &lt;j.smith@gmail.com&gt;<br><b>Sent:</b> Thursday, April 23, 2020 4:14 PM<br><b>To:</b> Foo Bar &lt;foo.bar@gmail.com&gt;<br><b>Subject:</b> Re: Test inline reply</font><div>&nbsp;</div></div><div><div style="background-color:#FF0000; ">WARNING: This email was sent from outside the organization.</div><div><div dir="ltr"><div class="x_gmail_quote"><div style="font-family:Verdana,Geneva,sans-serif; font-size:10pt; color:rgb(0,0,0)"><br></div><div style="font-family:Verdana,Geneva,sans-serif; font-size:10pt; color:rgb(0,0,0)">Test</div></div></div></div></div>';
+
+let doc: Document;
+
+beforeEach(() => {
+  var parser = new DOMParser();
+  doc = parser.parseFromString(testHtmlBody, "text/html");
+});
+
+test("Extract font style from HTML body", () => {
+  expect(getFontStyle(testHtmlBody)).toMatch(
+    '<div style="font-family: Verdana, Geneva, sans-serif; font-size: 10pt; color: rgb(0, 0, 0);">'
+  );
+});
+
+test("Get citation in email reply", () => {
+  expect(getCitation(doc)).toBe("On Thursday, April 23, 2020 4:14 PM, John Smith &lt;j.smith@gmail.com&gt; wrote:");
+});
+
+test("Remove header in email reply", () => {
+  removeEmailHeader(doc);
+  expect(doc.getElementById("divRplyFwdMsg")).toBeNull();
+});
+
+test("Removing external sender warning", () => {
+  removeExternalSenderWarning(
+    doc.body,
+    '<div style="background-color:#FF0000; ">WARNING: This email was sent from outside the organization.</div>'
+  );
+  expect(doc.body.innerHTML).toBe(
+    '<div style="font-family: Verdana, Geneva, sans-serif; font-size: 10pt; color: rgb(0, 0, 0);"><br></div><div id="appendonsend"></div><div style="font-family:Verdana,Geneva,sans-serif; font-size:10pt; color:rgb(0,0,0)"><br></div><hr tabindex="-1" style="display:inline-block; width:98%"><div id="divRplyFwdMsg" dir="ltr"><font face="Calibri, sans-serif" color="#000000" style="font-size:11pt"><b>From:</b> John Smith &lt;j.smith@gmail.com&gt;<br><b>Sent:</b> Thursday, April 23, 2020 4:14 PM<br><b>To:</b> Foo Bar &lt;foo.bar@gmail.com&gt;<br><b>Subject:</b> Re: Test inline reply</font><div>&nbsp;</div></div><div><div><div dir="ltr"><div class="x_gmail_quote"><div style="font-family:Verdana,Geneva,sans-serif; font-size:10pt; color:rgb(0,0,0)"><br></div><div style="font-family:Verdana,Geneva,sans-serif; font-size:10pt; color:rgb(0,0,0)">Test</div></div></div></div></div>'
+  );
+});
 
 test("Adding blockquote to HTML email", () => {
-  expect(addQuotesToEmail("ABC", "html")).toMatch(/<blockquote(.|\n|\r)*<\/blockquote>/);
+  addQuotesToEmail(doc.body);
+  expect(doc.body.innerHTML).toMatch(/<blockquote(.|\n|\r)*<\/blockquote>/);
 });

--- a/src/commands/formatter.ts
+++ b/src/commands/formatter.ts
@@ -1,25 +1,133 @@
+import * as userSettings from "../common/userSettings";
+
 /**
  * Reformats an email body to support inline replies
  *
  * @param {string} body
  *        The email body
- * @param {object} preferences
+ * @param {boolean} isHtml
+ *        True for HTML body, False for plain text
+ * @param {userSettings.Preferences} preferences
  *        User preferences
  *
  * @returns {string}
  *          The modified email body
  */
-export function reformatEmailBody(body: string, preferences: object): string {
+export function reformatEmailBody(body: string, isHtml: boolean, preferences: userSettings.Preferences): string {
+  if (!isHtml) {
+    console.warn("Not supported yet. Doing nothing.");
+  }
+
   console.log("reformatEmailBody: received preferences", preferences);
+  console.log("reformatEmailBody: original content:\n", body);
 
-  // Remove email header if preferred
-  // Remove external sender if preferred
+  var modifiedBody = "";
+  var contentToQuote = body;
 
-  var newBody = addQuotesToEmail(body, "html");
+  // Obtain the div text style
+  var fontStyle = getFontStyle(body);
+  console.log("divStyle:", fontStyle);
+  modifiedBody += `${fontStyle}<br>`;
 
-  // Add a new line (unquoted) before the body for user input
+  // Extract email header and replace it with "On DATE TIME, NAME <EMAIL> wrote"
+  if (preferences.replaceHeader) {
+    // Extract the sender and the time from the quoted email
+    var citation = getCitation(body);
+    modifiedBody += citation;
 
-  return newBody;
+    // Remove the email header
+    var contentToQuote = getHeaderlessContent(contentToQuote);
+  }
+  modifiedBody += "</div>";
+
+  // Remove external sensor warning
+  if (preferences.removeExternalWarning)
+    contentToQuote = removeExternalSenderWarning(contentToQuote, preferences.externalWarningHtml);
+
+  // Add quotes to email
+  var quotedContent = addQuotesToEmail(contentToQuote, "html");
+
+  // Combine the new body to return, with a new line for user input
+  modifiedBody += quotedContent;
+
+  return modifiedBody;
+}
+
+/**
+ * Extracts the font style from the email body
+ *
+ * @param {string} body
+ *        The email body
+ *
+ * @returns {string}
+ *          The <div> tag containing the font style
+ */
+export function getFontStyle(body: string) {
+  var result = body.match(/<div style[^>]+>/);
+  if (result == null) return "<div>";
+
+  return result[0];
+}
+
+/**
+ * Gets the citation string from the expanded email body
+ *
+ * @param {string} body
+ *        The email body
+ *
+ * @returns {string}
+ *          The citation string with the format "On TIMESTAMP, SENDER <EMAIL> wrote:"
+ */
+export function getCitation(body: string) {
+  // Extract sender name and email
+  var nameRe = /(?<=<b>(.)+:<\/b> )(.)*&lt;\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b&gt;/;
+  var matchResult = body.match(nameRe);
+  if (matchResult == null) return "";
+  var senderString = matchResult[0];
+  var nextIndex = matchResult.index + senderString.length;
+  console.log("Sender found:", senderString);
+
+  // Extract sent time and date
+  var timestampRe = /(?<=<b>(.)+:<\/b> )(.)+(?=<br>)/;
+  matchResult = body.substring(nextIndex).match(timestampRe);
+  if (matchResult == null) return "";
+  var timestamp = matchResult[0];
+  console.log("Timestamp found:", timestamp);
+
+  // Put the citation string together
+  var citation = `On ${timestamp}, ${senderString} wrote:`;
+
+  return citation;
+}
+
+/**
+ * Removes the email header of an expanded email body
+ *
+ * @param {string} body
+ *        The email body
+ *
+ * @returns {string}
+ *          The modified body with the email header removed
+ */
+export function getHeaderlessContent(body: string) {
+  var pattern = /<hr (.)+>(\n)*<div (.)+(\n)*(<b>(.)+(\n)*)+((.)*\n)<\/div>/;
+  return body.replace(pattern, "");
+}
+
+/**
+ * Removes the warning about an external sender
+ *
+ * @param {string} content
+ *        The email body
+ * @param {string} externalSenderWarning
+ *        The pattern of the external sender warning
+ *
+ * @returns {string}
+ *          The email body with the external sender warning removed
+ */
+export function removeExternalSenderWarning(content: string, externalSenderWarning: string) {
+  // TODO: only look in the first quoted message!
+  return content.replace(externalSenderWarning, "");
 }
 
 /**
@@ -27,18 +135,18 @@ export function reformatEmailBody(body: string, preferences: object): string {
  *
  * @param {string} content
  *        The content of the email
- * @param {string} format
- *        The format of the email
  *
  * @returns {string}
  *          The quoted email content
  */
-export function addQuotesToEmail(content, format = "html"): string {
+export function addQuotesToEmail(content: string): string {
   // If HTML, add blockquote
   // If plain text, remove redundant new lines if preferred, and then add "> " in front of everyline
-  format;
+
+  // var blockquoteTag =
+  // '<blockquote class="x_gmail_quote" style="margin:0px 0px 0px 0.8ex; border-left:1px solid rgb(204,204,204); padding-left:1ex">';
   var blockquoteTag =
-    '<blockquote class="x_gmail_quote" style="margin:0px 0px 0px 0.8ex; border-left:1px solid rgb(204,204,204); padding-left:1ex">';
+    '<blockquote style="border-left: 3px solid rgb(200, 200, 200); border-top-color: rgb(200, 200, 200); border-right-color: rgb(200, 200, 200); border-bottom-color: rgb(200, 200, 200); padding-left: 1ex; margin-left: 0.8ex; color: rgb(102, 102, 102);">';
 
   var newContent = blockquoteTag + content + "</blockquote>";
   return newContent;

--- a/src/commands/formatter.ts
+++ b/src/commands/formatter.ts
@@ -1,3 +1,5 @@
+/* eslint-env browser */
+
 import * as userSettings from "../common/userSettings";
 
 /**
@@ -18,37 +20,41 @@ export function reformatEmailBody(body: string, isHtml: boolean, preferences: us
     console.warn("Not supported yet. Doing nothing.");
   }
 
-  console.log("reformatEmailBody: received preferences", preferences);
-  console.log("reformatEmailBody: original content:\n", body);
-
+  var parser = new DOMParser();
+  var contentToQuote = parser.parseFromString(body, "text/html");
   var modifiedBody = "";
-  var contentToQuote = body;
 
-  // Obtain the div text style
-  var fontStyle = getFontStyle(body);
+  console.log("reformatEmailBody: received preferences", preferences);
+  console.log("reformatEmailBody: original content:\n", contentToQuote.body.innerHTML);
+
+  // Obtain the div font style
+  var fontStyle = getFontStyle(contentToQuote.body.innerHTML);
   console.log("divStyle:", fontStyle);
-  modifiedBody += `${fontStyle}<br>`;
+  modifiedBody += `${fontStyle}<br><br>`;
 
   // Extract email header and replace it with "On DATE TIME, NAME <EMAIL> wrote"
   if (preferences.replaceHeader) {
     // Extract the sender and the time from the quoted email
-    var citation = getCitation(body);
+    var citation = getCitation(contentToQuote);
+    console.log("citation:", citation);
     modifiedBody += citation;
 
     // Remove the email header
-    var contentToQuote = getHeaderlessContent(contentToQuote);
+    removeEmailHeader(contentToQuote);
   }
+
+  // Close the div of the fonts style
   modifiedBody += "</div>";
 
   // Remove external sender warning
   if (preferences.removeExternalWarning)
-    contentToQuote = removeExternalSenderWarning(contentToQuote, preferences.externalWarningHtml);
+    removeExternalSenderWarning(contentToQuote.body, preferences.externalWarningHtml);
 
   // Add quotes to email
-  var quotedContent = addQuotesToEmail(contentToQuote);
+  addQuotesToEmail(contentToQuote.body);
 
   // Combine the new body to return, with a new line for user input
-  modifiedBody += quotedContent;
+  modifiedBody += contentToQuote.body.innerHTML;
 
   return modifiedBody;
 }
@@ -63,7 +69,10 @@ export function reformatEmailBody(body: string, isHtml: boolean, preferences: us
  *          The <div> tag containing the font style
  */
 export function getFontStyle(body: string) {
+  // The font style is in the first <div style=... > tag
   var result = body.match(/<div style[^>]+>/);
+
+  // If there is no font style, just return an empty div tag
   if (result == null) return "<div>";
 
   return result[0];
@@ -72,25 +81,35 @@ export function getFontStyle(body: string) {
 /**
  * Gets the citation string from the expanded email body
  *
- * @param {string} body
- *        The email body
+ * @param {Document} doc
+ *        The email HTML structure
  *
  * @returns {string}
  *          The citation string with the format "On TIMESTAMP, SENDER <EMAIL> wrote:"
  */
-export function getCitation(body: string) {
+export function getCitation(doc: Document) {
+  var headerParts = doc.getElementById("divRplyFwdMsg").innerHTML.split("<br>");
+  console.log("Header:", headerParts);
+
+  var timestamp = "A";
+
   // Extract sender name and email
-  var nameRe = /(?<=<b>(.)+:<\/b> )(.)*&lt;\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b&gt;/;
-  var matchResult = body.match(nameRe);
-  if (matchResult == null) return "";
+  var nameRe = /(?<=<b>(.)+:<\/b> ).*&lt;\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b&gt;/;
+  var matchResult = headerParts[0].match(nameRe);
+  if (matchResult == null) {
+    console.log("Sender not found!");
+    return "";
+  }
   var senderString = matchResult[0];
-  var nextIndex = matchResult.index + senderString.length;
   console.log("Sender found:", senderString);
 
   // Extract sent time and date
-  var timestampRe = /(?<=<b>(.)+:<\/b> )(.)+(?=<br>)/;
-  matchResult = body.substring(nextIndex).match(timestampRe);
-  if (matchResult == null) return "";
+  var timestampRe = /(?<=<b>(.)+:<\/b> )(.)+/;
+  matchResult = headerParts[1].match(timestampRe);
+  if (matchResult == null) {
+    console.log("Timestamp not found!");
+    return "";
+  }
   var timestamp = matchResult[0];
   console.log("Timestamp found:", timestamp);
 
@@ -103,51 +122,83 @@ export function getCitation(body: string) {
 /**
  * Removes the email header of an expanded email body
  *
- * @param {string} body
- *        The email body
+ * @param {Document} doc
+ *        The email HTML structure
  *
- * @returns {string}
- *          The modified body with the email header removed
+ * @returns {boolean}
+ *          true on success, false otherwise
  */
-export function getHeaderlessContent(body: string) {
-  var pattern = /<hr (.)+>(\n)*<div (.)+(\n)*(<b>(.)+(\n)*)+((.)*\n)<\/div>/;
-  return body.replace(pattern, "");
+export function removeEmailHeader(doc: Document): boolean {
+  // var pattern = /<hr (.)+>(\n)*<div (.)+(\n)*(<b>(.)+(\n)*)+((.)*\n)<\/div>/;
+
+  // Remove the <div id="divRplyFwdMsg" ...> tag
+  doc.getElementById("divRplyFwdMsg").remove();
+
+  // Remove the horizontal rule
+  var hrList = doc.getElementsByTagName("hr");
+  if (hrList.length > 0) {
+    hrList[0].parentNode.removeChild(hrList[0]);
+  }
+
+  return true;
 }
 
 /**
  * Removes the warning about an external sender
  *
- * @param {string} content
- *        The email body
+ * @param {HTMLElement} body
+ *        The email HTML body
  * @param {string} externalSenderWarning
  *        The pattern of the external sender warning
  *
- * @returns {string}
- *          The email body with the external sender warning removed
+ * @returns {boolean}
+ *          true on success, false otherwise
  */
-export function removeExternalSenderWarning(content: string, externalSenderWarning: string) {
+export function removeExternalSenderWarning(body: HTMLElement, externalSenderWarning: string): boolean {
   // TODO: only look in the first quoted message!
-  return content.replace(externalSenderWarning, "");
+
+  // Remove the external warning when it's exactly seen
+  body.innerHTML = body.innerHTML.replace(externalSenderWarning, "");
+
+  return true;
 }
 
 /**
  * Adds quotes to an email content
  *
- * @param {string} content
+ * @param {HTMLElement} body
  *        The content of the email
  *
- * @returns {string}
- *          The quoted email content
+ * @returns {boolean}
+ *          true on success, false otherwise
  */
-export function addQuotesToEmail(content: string): string {
+export function addQuotesToEmail(body: HTMLElement): boolean {
   // If HTML, add blockquote
   // If plain text, remove redundant new lines if preferred, and then add "> " in front of everyline
 
   // var blockquoteTag =
   // '<blockquote class="x_gmail_quote" style="margin:0px 0px 0px 0.8ex; border-left:1px solid rgb(204,204,204); padding-left:1ex">';
-  var blockquoteTag =
-    '<blockquote style="border-left: 3px solid rgb(200, 200, 200); border-top-color: rgb(200, 200, 200); border-right-color: rgb(200, 200, 200); border-bottom-color: rgb(200, 200, 200); padding-left: 1ex; margin-left: 0.8ex; color: rgb(102, 102, 102);">';
+  // var blockquoteTag =
+  //   '<blockquote style="border-left: 3px solid rgb(200, 200, 200); border-top-color: rgb(200, 200, 200); border-right-color: rgb(200, 200, 200); border-bottom-color: rgb(200, 200, 200); padding-left: 1ex; margin-left: 0.8ex; color: rgb(102, 102, 102);">';
 
-  var newContent = blockquoteTag + content + "</blockquote>";
-  return newContent;
+  // var newContent = blockquoteTag + content + "</blockquote>";
+
+  var blockquote = document.createElement("blockquote");
+
+  // Outlook style blockquote
+  blockquote.style.borderLeft = "3px solid rgb(200, 200, 200)";
+  blockquote.style.borderColor = "rgb(200, 200, 200)";
+  blockquote.style.paddingLeft = "1ex";
+  blockquote.style.marginLeft = "0.8ex";
+  blockquote.style.color = "rgb(102, 102, 102)";
+
+  // Move all the current children elements into the blockquote element
+  while (body.firstChild) {
+    blockquote.appendChild(body.firstChild);
+  }
+
+  // Append the blockquote element to the body
+  body.appendChild(blockquote);
+
+  return true;
 }

--- a/src/commands/formatter.ts
+++ b/src/commands/formatter.ts
@@ -45,7 +45,7 @@ export function reformatEmailBody(body: string, isHtml: boolean, preferences: us
     contentToQuote = removeExternalSenderWarning(contentToQuote, preferences.externalWarningHtml);
 
   // Add quotes to email
-  var quotedContent = addQuotesToEmail(contentToQuote, "html");
+  var quotedContent = addQuotesToEmail(contentToQuote);
 
   // Combine the new body to return, with a new line for user input
   modifiedBody += quotedContent;

--- a/src/commands/formatter.ts
+++ b/src/commands/formatter.ts
@@ -40,7 +40,7 @@ export function reformatEmailBody(body: string, isHtml: boolean, preferences: us
   }
   modifiedBody += "</div>";
 
-  // Remove external sensor warning
+  // Remove external sender warning
   if (preferences.removeExternalWarning)
     contentToQuote = removeExternalSenderWarning(contentToQuote, preferences.externalWarningHtml);
 

--- a/src/common/userSettings.ts
+++ b/src/common/userSettings.ts
@@ -1,0 +1,15 @@
+// Interface for user preferences
+export interface Preferences {
+  polishPlainText: boolean;
+  replaceHeader: boolean;
+  removeExternalWarning: boolean;
+  externalWarningHtml: string;
+}
+
+// Default user preferences
+export const defaultPreferences: Preferences = {
+  polishPlainText: false,
+  replaceHeader: true,
+  removeExternalWarning: true,
+  externalWarningHtml: ""
+};

--- a/src/taskpane/components/App.tsx
+++ b/src/taskpane/components/App.tsx
@@ -5,6 +5,7 @@ import Header from "./Header";
 import Progress from "./Progress";
 import ToggleList, { ToggleListItem } from "./ToggleList";
 import TextFieldWithButtons from "./TextFieldWithButtons";
+import * as userSettings from "../../common/userSettings";
 /* global Button, Header, HeroList, HeroListItem, Progress */
 
 export interface AppProps {
@@ -16,14 +17,6 @@ export interface AppState {
   preferences: object;
   statistics: object;
 }
-
-// Default values for the preferences
-var defaultPreferences = {
-  polishPlainText: false,
-  replaceHeader: true,
-  removeExternalWarning: true,
-  externalWarningHtml: ""
-};
 
 // Default values for usage statistics
 var defaultStatistics = {
@@ -53,7 +46,7 @@ export default class App extends React.Component<AppProps, AppState> {
   constructor(props, context) {
     super(props, context);
     this.state = {
-      preferences: defaultPreferences,
+      preferences: userSettings.defaultPreferences,
       statistics: defaultStatistics
     };
   }
@@ -81,14 +74,14 @@ export default class App extends React.Component<AppProps, AppState> {
   refreshRoamingSettings = () => {
     // Set the state from the roaming settings
     this.setState(_prevState => ({
-      preferences: this.readRoamingSettings("preferences", defaultPreferences),
+      preferences: this.readRoamingSettings("preferences", userSettings.defaultPreferences),
       statistics: this.readRoamingSettings("statistics", defaultStatistics)
     }));
   };
 
   loadDefaultPreferences = () => {
     this.setState(_prevState => ({
-      preferences: defaultPreferences
+      preferences: userSettings.defaultPreferences
     }));
   };
 


### PR DESCRIPTION
This pull request contains the following features when replying to an email:
- Replace the multi-line header in Outlook with a single line "On TIMESTAMP, SENDER <EMAIL> wrote:" #3 
- Remove the external sender warning #8 